### PR TITLE
Detail top page

### DIFF
--- a/app/controllers/api/v1/dragons_controller.rb
+++ b/app/controllers/api/v1/dragons_controller.rb
@@ -4,8 +4,8 @@ module Api
       before_action :set_dragon, only: %i[show]
 
       def show
-        user = Dragon.find_by(id: params[:id])
-        render json: user
+        dragon = Dragon.find_by(id: params[:id])
+        render json: dragon
       end
 
       private

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class='d-flex flex-column min-vh-100 bg-cover bg-fixed pt-32' :style="{ backgroundImage: 'url(' + image_src + ')' }">
+  <div class='d-flex flex-column min-vh-100 bg-cover bg-fixed pt-24' :style="{ backgroundImage: 'url(' + image_src + ')' }">
     <TheHeader class='mb-auto' />
       <router-view />
     <TheFooter class='mt-auto' />

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class='d-flex flex-column min-vh-100 bg-cover bg-fixed pt-24' :style="{ backgroundImage: 'url(' + image_src + ')' }">
+  <div class='d-flex flex-column min-h-screen bg-cover bg-fixed bg-center pt-32' :style="{ backgroundImage: 'url(' + image_src + ')' }">
     <TheHeader class='mb-auto' />
       <router-view />
     <TheFooter class='mt-auto' />

--- a/app/javascript/components/TheFooter.vue
+++ b/app/javascript/components/TheFooter.vue
@@ -1,6 +1,6 @@
 <template>
   <footer>
-    <div class="bg-gray-100 w-full py-4">
+    <div class="bg-gray-100 w-full py-4 sticky bottom-0">
       <div class='max-w-screen-xl mx-auto p-4'>
         <ul class="max-w-screen-md mx-auto text-xl font-light flex justify-center">
           <li class="my-2 px-4">

--- a/app/javascript/components/TheFooter.vue
+++ b/app/javascript/components/TheFooter.vue
@@ -2,11 +2,11 @@
   <footer>
     <div class="bg-gray-100 w-full py-4">
       <div class='max-w-screen-xl mx-auto p-4'>
-        <ul class="max-w-screen-md mx-auto text-2xl font-light flex justify-center">
+        <ul class="max-w-screen-md mx-auto text-xl font-light flex justify-center">
           <li class="my-2 px-4">
             <router-link
               to="/term"
-              class="text-gray-500 hover:text-gray-800"
+              class="p-2 lg:px-4 md:mx-2 text-xl text-gray-500 text-center border border-transparent rounded hover:bg-red-100 hover:text-red-700 transition-colors duration-300"
             >
               利用規約
             </router-link>
@@ -14,7 +14,7 @@
           <li class="my-2 px-4">
             <router-link
               to="/privacypolicy"
-              class="text-gray-500 hover:text-gray-800"
+              class="p-2 lg:px-4 md:mx-2 text-xl text-gray-500 text-center border border-transparent rounded hover:bg-red-100 hover:text-red-700 transition-colors duration-300"
             >
               プライバシーポリシー
             </router-link>
@@ -22,13 +22,13 @@
           <li class="my-2 px-4">
             <a
               href="https://twitter.com/Umesho0415"
-              class="text-gray-500 hover:text-gray-800"
+              class="p-2 rounded text-twitterBlue hover:text-white hover:bg-twitterBlue"
             >
               <i class="ri-twitter-fill"></i>
             </a>
           </li>
         </ul>
-        <div class="text-center text-gray-500 p-2 text-2xl font-light flex items-center justify-center">
+        <div class="text-center text-gray-500 p-2 text-xl font-light flex items-center justify-center">
           ©2022 Dratter
         </div>
       </div>

--- a/app/javascript/components/TheHeader.vue
+++ b/app/javascript/components/TheHeader.vue
@@ -1,39 +1,37 @@
 <template>
   <header>
-    <div class='w-full text-gray-500 bg-gray-100 p-2 fixed top-0'>
-      <div class='items-center max-w-screen-xl mx-auto md:px-4'>
-        <div class='flex flex-row justify-between p-1'>
-          <router-link to="/" class="flex justify-center items-center">
-            <img :src="logo_src" width="100px" >
-          </router-link>
-          <nav class='text-right md:pb-0 md:flex md:flex-row'>
-            <a
-              href='/api/v1/oauth/twitter' v-if="!currentUser"
-              class='block text-2xl text-right hover:text-white hover:bg-gray-600 rounded'
+    <nav class='w-full text-gray-500 bg-gray-100 p-2 fixed top-0'>
+      <div class='container px-4 mx-auto'>
+        <div class="flex justify-between items-center">
+        <router-link to="/" class='flex justify-center items-center'>
+          <img :src="logo_src" width="100px" >
+        </router-link>
+        <div>
+          <a
+            href='/api/v1/oauth/twitter' v-if="!currentUser"
+            class='p-2 lg:px-4 md:mx-2 text-xl text-gray-500 text-center border border-transparent rounded hover:bg-red-100 hover:text-red-700 transition-colors duration-300'
+          >
+            Twitter認証によるユーザー登録
+          </a>
+          <button @click="isOpen = !isOpen">
+            <img
+              :src="currentUser.image" class='object-cover border-2 rounded-full h-16 w-16'  v-if="currentUser"
             >
-              Twitter認証によるユーザー登録
-            </a>
-            <router-link v-if="currentUser" :to="`/users/${this.currentUser.screen_name}`">
-              <img
-                :src="user_avatar_src" class='mx-auto object-cover border-2 rounded-full h-16 w-16'
-              >
+          </button>
+        </div>
+        </div>
+        <div :class="isOpen ? 'flex' : 'hidden'" class="flex-col mt-3 justify-between" v-if="currentUser">
+          <button @click="closeMenu" class="p-2 lg:px-4 text-xl text-gray-500 text-center border border-transparent rounded hover:bg-red-100 hover:text-red-700 transition-colors duration-300">
+            <router-link :to="`/users/${this.currentUser.screen_name}`">
+              マイページ
             </router-link>
-            <button
-              v-if="currentUser" @click="logout"
-              class='block text-2xl text-right hover:text-white hover:bg-gray-600 rounded'
-            >
-              ログアウト
-            </button>
-            <button
-              v-if="currentUser" @click="deleteUser"
-              class='block text-2xl text-right hover:text-white hover:bg-gray-600 rounded'
-            >
-              ユーザー削除
-            </button>
-          </nav>
+          </button>
+          <button @click="logout" class="p-2 lg:px-4 text-xl text-gray-500 text-center border border-transparent rounded hover:bg-red-100 hover:text-red-700 transition-colors duration-300">
+            ログアウト
+          </button>
         </div>
       </div>
-    </div>
+    </nav>
   </header>
 </template>
 
@@ -43,6 +41,8 @@ import { mapGetters　} from "vuex"
 
 export default {
   name: 'TheHeader',
+  components: {
+  },
   data() {
     return {
       isOpen: false,
@@ -69,14 +69,9 @@ export default {
         err => console.log(err.response)
       }
     },
-    async deleteUser() {
-      try {
-        await this.$store.dispatch('users/deleteCurrentUser')
-        await this.$router.push('/')
-      } catch(err){
-        err => console.log(err.response)
-      }
-    }
+    closeMenu(){
+      this.isOpen = false;
+    },
   }
 }
 </script>

--- a/app/javascript/components/TheHeader.vue
+++ b/app/javascript/components/TheHeader.vue
@@ -1,10 +1,10 @@
 <template>
   <header>
     <nav class='w-full text-gray-500 bg-gray-100 p-2 fixed top-0'>
-      <div class='container px-4 mx-auto'>
+      <div class='px-12 mx-auto items-center'>
         <div class="flex justify-between items-center">
         <router-link to="/" class='flex justify-center items-center'>
-          <img :src="logo_src" width="100px" >
+          <img :src="logo_src" width="100px" @click="closeMenu">
         </router-link>
         <div>
           <a
@@ -15,18 +15,18 @@
           </a>
           <button @click="isOpen = !isOpen">
             <img
-              :src="currentUser.image" class='object-cover border-2 rounded-full h-16 w-16'  v-if="currentUser"
+              :src="currentUser.image" class='object-cover border-2 rounded-full h-20 w-20'  v-if="currentUser"
             >
           </button>
         </div>
         </div>
         <div :class="isOpen ? 'flex' : 'hidden'" class="flex-col mt-3 justify-between" v-if="currentUser">
-          <button @click="closeMenu" class="p-2 lg:px-4 text-xl text-gray-500 text-center border border-transparent rounded hover:bg-red-100 hover:text-red-700 transition-colors duration-300">
+          <button @click="closeMenu" class="p-2 lg:px-4 text-2xl text-gray-500 text-center border border-transparent rounded hover:bg-red-100 hover:text-red-700 transition-colors duration-300">
             <router-link :to="`/users/${this.currentUser.screen_name}`">
               マイページ
             </router-link>
           </button>
-          <button @click="logout" class="p-2 lg:px-4 text-xl text-gray-500 text-center border border-transparent rounded hover:bg-red-100 hover:text-red-700 transition-colors duration-300">
+          <button @click="logout" class="p-2 lg:px-4 text-2xl text-gray-500 text-center border border-transparent rounded hover:bg-red-100 hover:text-red-700 transition-colors duration-300">
             ログアウト
           </button>
         </div>

--- a/app/javascript/components/UserProfileCard.vue
+++ b/app/javascript/components/UserProfileCard.vue
@@ -1,5 +1,4 @@
 <template>
-<!-- component -->
   <div class="w-full max-w-md mx-auto bg-white shadow-md rounded-md px-6 py-4 my-6">
     <div class="sm:flex justify-left">
       <div class="flex items-center">
@@ -14,8 +13,7 @@
       <button class="bg-twitterBlue hover:bg-blue-700 text-white text-2xl font-bold py-4 px-4 rounded" @click="updateUserSettings">ユーザー情報を更新する</button>
     </div>
     <div class="mt-3">
-      <h4 class="text-gray-600 text-sm"></h4>
-      <span class="mt-2 text-xl font-medium text-gray-800"></span>
+      <button class="bg-twitterBlue hover:bg-blue-700 text-white text-2xl font-bold py-4 px-4 rounded" @click="logoutUser">退会する</button>
     </div>
     <div class="mt-4">
       <h4 class="text-sm text-gray-600"></h4>
@@ -46,6 +44,9 @@ export default {
     updateUserSettings() {
       this.$emit("update-Settings");
     },
+    logoutUser() {
+      this.$emit("logout")
+    }
   }
 }
 </script>

--- a/app/javascript/components/UserProfileCard.vue
+++ b/app/javascript/components/UserProfileCard.vue
@@ -1,37 +1,37 @@
 <template>
-  <div class="w-full max-w-md mx-auto bg-white shadow-md rounded-md px-6 py-4 my-6">
-    <div class="sm:flex justify-left">
+  <div class="w-full mx-auto bg-white shadow-md rounded-md px-6 py-4 my-12">
+    <div class="sm:flex justify-left py-4">
       <div class="flex items-center">
-        <img class="h-12 w-12 rounded-full" :src="user.image" alt="">
-        <div class="ml-2">
-          <h3 class="text-2xl text-gray-800 font-medium">{{ user.name }}</h3>
-          <span class="text-2xl text-gray-600">{{ user.screen_name }}</span>
+        <img class="h-20 w-20 rounded-full" :src="user.image" alt="">
+        <div class="ml-4 text-left">
+          <h3 class="text-3xl text-gray-800 font-medium">{{ user.name }}</h3>
+          <h3 class="text-3xl text-gray-600">@{{ user.screen_name }}</h3>
         </div>
      </div>
     </div>
-    <div class="flex justify-center items-center mt-4">
-      <button class="bg-twitterBlue hover:bg-blue-700 text-white text-2xl font-bold py-4 px-4 rounded" @click="updateUserSettings">ユーザー情報を更新する</button>
+    <div class="text-2xl pt-4 border-t-2">次のボタンを押すとTwitterの最新プロフィールに更新されます</div>
+    <div class="flex flex-row justify-center items-center my-4">
+      <button class=" bg-twitterBlue hover:bg-blue-700 text-white text-2xl font-bold py-4 px-4 rounded" @click="updateUserSettings">
+        <i class="ri-restart-line mx-2"></i>ユーザー情報を更新する
+      </button>
     </div>
-    <div class="mt-3">
-      <button class="bg-twitterBlue hover:bg-blue-700 text-white text-2xl font-bold py-4 px-4 rounded" @click="logoutUser">退会する</button>
+    <div class="flex flex-row justify-center items-center text-2xl pt-4 border-t-2">
+      <input type="checkbox" v-model="checkbox" class="mr-2">退会する場合は全ての情報が削除されます。
     </div>
-    <div class="mt-4">
-      <h4 class="text-sm text-gray-600"></h4>
-      <div class="flex items-center overflow-hidden mt-2">
-      </div>
+    <div class="my-4">
+      <button class="bg-red-500 hover:bg-red-700 text-white text-2xl font-bold py-4 px-4 rounded" @click="logoutUser" :disabled="!checkbox">退会する</button>
     </div>
-    <div class="mt-4">
-      <h4 class="text-sm text-gray-600"></h4>
-      <div class="flex items-center overflow-hidden mt-2">
-      </div>
-    </div>
-    <a class="block mt-4 text-blue-400 hover:underline" href="#"></a>
   </div>
 </template>
 
 <script>
 export default {
   name: "UserProfileCard",
+  data() {
+    return {
+      checkbox: false
+    }
+  },
   props: {
     user: {
       type: Object,

--- a/app/javascript/pages/Dragon.vue
+++ b/app/javascript/pages/Dragon.vue
@@ -4,21 +4,21 @@
       <div class="col-start-2 col-span-10 mt-20 md:mt-0">
         <div class="text-2xl inline p-2 text-white font-bold border-b-8 border-white md:text-4xl">{{ title }}</div>
       </div>
-      <div class="text-center text-white col-start-2 col-span-10 px-10 pb-10 mx-auto" v-if="this.dragon.attributes">
+      <div class="text-center text-white col-start-2 col-span-10 px-10 pb-10 mx-auto" v-if="dragon.attributes">
         <div class="text-6xl font-bold">
-          <h3>{{ this.dragon.attributes.name }}</h3>
+          <h3>{{ dragon.attributes.name }}</h3>
         </div>
         <div class="m-auto">
           <img :src="dragon_image_src">
         </div>
-        <div class="p-4 m-4 border-4 border-white rounded-md font-bold mx-16">
+        <div class="p-4 m-4 border-4 border-white rounded-md font-bold mx-4">
           <div class="text-3xl inline font-bold border-b-2 border-white">性格</div>
-          <div class="text-3xl m-4">{{ this.dragon.attributes.explanation }}</div>
-          <div class="text-2xl m-4">{{ this.dragon.attributes.personality }}</div>
+          <div class="text-3xl m-4">{{ dragon.attributes.explanation }}</div>
+          <div class="text-2xl m-4 text-left">{{ dragon.attributes.personality }}</div>
         </div>
-        <div class="p-4 m-4 border-4 border-white rounded-md font-bold mx-16">
+        <div class="p-4 m-4 border-4 border-white rounded-md font-bold mx-4">
           <div class="text-3xl inline font-bold border-b-2 border-white">アドバイス</div>
-          <div class="text-2xl m-4">{{ this.dragon.attributes.advice }}</div>
+          <div class="text-2xl m-4 text-left">{{ dragon.attributes.advice }}</div>
         </div>
       </div>
     </div>

--- a/app/javascript/pages/Dragon.vue
+++ b/app/javascript/pages/Dragon.vue
@@ -4,21 +4,21 @@
       <div class="col-start-2 col-span-10 mt-20 md:mt-0">
         <div class="text-2xl inline p-2 text-white font-bold border-b-8 border-white md:text-4xl">{{ title }}</div>
       </div>
-      <div class="text-center text-white col-start-2 col-span-10 px-10 pb-10 mx-auto" v-if="dragons.attributes">
+      <div class="text-center text-white col-start-2 col-span-10 px-10 pb-10 mx-auto" v-if="this.dragon.attributes">
         <div class="text-6xl font-bold">
-          <h3>{{ dragon.attributes.name }}</h3>
+          <h3>{{ this.dragon.attributes.name }}</h3>
         </div>
         <div class="m-auto">
           <img :src="dragon_image_src">
         </div>
         <div class="p-4 m-4 border-4 border-white rounded-md font-bold mx-16">
           <div class="text-3xl inline font-bold border-b-2 border-white">性格</div>
-          <div class="text-3xl m-4">{{ dragon.attributes.explanation }}</div>
-          <div class="text-2xl m-4">{{ dragon.attributes.personality }}</div>
+          <div class="text-3xl m-4">{{ this.dragon.attributes.explanation }}</div>
+          <div class="text-2xl m-4">{{ this.dragon.attributes.personality }}</div>
         </div>
         <div class="p-4 m-4 border-4 border-white rounded-md font-bold mx-16">
           <div class="text-3xl inline font-bold border-b-2 border-white">アドバイス</div>
-          <div class="text-2xl m-4">{{ dragon.attributes.advice }}</div>
+          <div class="text-2xl m-4">{{ this.dragon.attributes.advice }}</div>
         </div>
       </div>
     </div>
@@ -33,7 +33,7 @@ import axios from 'axios';
 import { mapGetters } from 'vuex'
 
 export default {
-  name: "dragon",
+  name: "Dragon",
   data() {
     return {
       title: "あなたの心に潜むドラゴンは…",

--- a/app/javascript/pages/User.vue
+++ b/app/javascript/pages/User.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="text-center">
+  <div class="text-center min-h-screen">
     <div class="grid grid-cols-12 gap-10 md:pt-20">
       <div class="col-start-2 col-span-10 mt-20 md:mt-0">
-        <div class="text-2xl inline p-2 text-white font-bold border-b-8 border-white md:text-4xl">{{ title }}</div>
+        <div class="text-3xl inline p-2 text-white font-bold border-b-8 border-white md:text-4xl">{{ title }}</div>
       </div>
-      <div class="text-center text-white col-start-2 col-span-10 px-10 pb-10 mx-auto">
+      <div class="items-center col-start-2 col-span-10">
         <UserProfileCard :user="currentUser" @update-Settings="updateUserSettings" @logout="deleteUser" />
       </div>
     </div>
@@ -23,7 +23,7 @@ export default {
   },
   data() {
     return {
-      title: "あなたの心に潜むドラゴンは…",
+      title: "マイページ",
       user: {},
     };
   },

--- a/app/javascript/pages/User.vue
+++ b/app/javascript/pages/User.vue
@@ -5,7 +5,7 @@
         <div class="text-2xl inline p-2 text-white font-bold border-b-8 border-white md:text-4xl">{{ title }}</div>
       </div>
       <div class="text-center text-white col-start-2 col-span-10 px-10 pb-10 mx-auto">
-        <UserProfileCard :user="currentUser" @update-Settings="updateUserSettings" />
+        <UserProfileCard :user="currentUser" @update-Settings="updateUserSettings" @logout="deleteUser" />
       </div>
     </div>
   </div>
@@ -17,7 +17,7 @@ import { mapGetters } from 'vuex'
 import UserProfileCard from '../components/UserProfileCard';
 
 export default {
-  name: "user",
+  name: "User",
   components: {
     UserProfileCard,
   },
@@ -51,9 +51,18 @@ export default {
     async updateUserSettings() {
       await axios.patch("/api/v1/user_settings")
       .then(res => {
-        this.$store.commit("users/setCurrentUser", res.data )
+        this.$store.commit("users/setCurrentUser", res.data)
       })
-    }
+    },
+   async deleteUser() {
+      try {
+        await axios.delete("/api/v1/user_settings")
+        await this.$router.push('/')
+      } catch(err){
+        this.$store.commit("users/setCurrentUser", null)
+        err => console.log(err.response)
+      }
+    },
   }
 }
 </script>

--- a/app/javascript/pages/privacyPolicy.vue
+++ b/app/javascript/pages/privacyPolicy.vue
@@ -56,7 +56,7 @@
       <p class="text-3xl mb-5 text-left">本サービスは、必要に応じて、このプライバシーポリシーの内容を変更します。</p>
 
       <div class="text-4xl font-bold mt-20 mb-10">第6条（お問い合わせ）</div>
-      <p class="text-3xl mb-5 text-left">お問い合わせの際は、公式アカウントのメッセージにて承ります。</p>
+      <p class="text-3xl mb-5 text-left">お問い合わせの際は、管理者アカウント(@Umesho0415)へのメッセージにて承ります。</p>
 
       <div class="text-3xl my-10 text-center">以上</div>
       <div class="text-3xl my-10 container text-center term-font  hover:opacity-50">

--- a/app/javascript/pages/result.vue
+++ b/app/javascript/pages/result.vue
@@ -37,7 +37,7 @@
 import { mapGetters } from 'vuex'
 
 export default {
-  name: "result",
+  name: "Result",
   data() {
     return {
       title: "あなたの心に潜むドラゴンは…"

--- a/app/javascript/pages/result.vue
+++ b/app/javascript/pages/result.vue
@@ -2,7 +2,7 @@
   <div class="text-center">
     <div class="grid grid-cols-12 gap-10 md:pt-20">
       <div class="col-start-2 col-span-10 mt-20 md:mt-0">
-        <div class="text-2xl inline p-2 text-white font-bold border-b-8 border-white md:text-4xl">{{ title }}</div>
+        <div class="text-2xl inline p-2 text-white font-bold border-b-8 border-white md:text-4xl">{{ results.target_account }}さんの心のドラゴンは…</div>
       </div>
       <div class="text-center text-white col-start-2 col-span-10 px-10 pb-10 mx-auto" v-if="dragons.attributes">
         <div class="text-6xl font-bold">
@@ -11,14 +11,14 @@
         <div class="m-auto">
           <img :src="dragon_image_src">
         </div>
-        <div class="p-4 m-4 border-4 border-white rounded-md font-bold mx-16">
+        <div class="p-4 m-4 border-4 border-white rounded-md font-bold mx-4">
           <div class="text-3xl inline font-bold border-b-2 border-white">性格</div>
           <div class="text-3xl m-4">{{ dragons.attributes.explanation }}</div>
-          <div class="text-2xl m-4">{{ dragons.attributes.personality }}</div>
+          <div class="text-2xl m-4 text-left">{{ dragons.attributes.personality }}</div>
         </div>
-        <div class="p-4 m-4 border-4 border-white rounded-md font-bold mx-16">
+        <div class="p-4 m-4 border-4 border-white rounded-md font-bold mx-4">
           <div class="text-3xl inline font-bold border-b-2 border-white">アドバイス</div>
-          <div class="text-2xl m-4">{{ dragons.attributes.advice }}</div>
+          <div class="text-2xl m-4 text-left">{{ dragons.attributes.advice }}</div>
         </div>
       </div>
     </div>

--- a/app/javascript/pages/top.vue
+++ b/app/javascript/pages/top.vue
@@ -38,7 +38,7 @@ import { mapGetters } from 'vuex'
 import Spinner from 'vue-spinner-component/src/Spinner.vue';
 
 export default {
-  name: "top",
+  name: "Top",
   data() {
     return {
       targetAccount: "",

--- a/app/javascript/pages/top.vue
+++ b/app/javascript/pages/top.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="text-center">
+  <div class="text-center min-h-screen">
     <div class="grid grid-cols-12 gap-10 my-32 md:my-12">
       <div class="col-start-2 col-span-10 pb-20 md:mt-0">
         <img :src="top_logo_src" height="1600px" width="400px" class="inline">

--- a/app/javascript/router/router.js
+++ b/app/javascript/router/router.js
@@ -2,13 +2,13 @@ import Vue from 'vue';
 import Router from 'vue-router';
 import VueGtag from 'vue-gtag';
 
-import Top from '../pages/top.vue';
-import Help from '../pages/help.vue';
-import Term from '../pages/term.vue';
-import PrivacyPolicy from '../pages/privacyPolicy.vue';
-import Result from '../pages/result.vue';
-import Dragons from '../pages/dragons';
-import Users from '../pages/users';
+import Top from '../pages/Top.vue';
+import Help from '../pages/Help.vue';
+import Term from '../pages/Term.vue';
+import PrivacyPolicy from '../pages/PrivacyPolicy.vue';
+import Result from '../pages/Result.vue';
+import Dragon from '../pages/Dragon.vue';
+import User from '../pages/User.vue';
 import NotFound from '../pages/shared/NotFound.vue';
 
 Vue.use(Router)
@@ -43,13 +43,13 @@ const router = new Router({
     },
     {
       path: "/dragons/:id",
-      component: Dragons,
-      name: "Dragons",
+      component: Dragon,
+      name: "Dragon",
     },
     {
       path: "/users/:id",
-      component: Users,
-      name: "Users",
+      component: User,
+      name: "User",
     },
     {
       name: "NotFound",

--- a/app/javascript/store/modules/users.js
+++ b/app/javascript/store/modules/users.js
@@ -29,7 +29,7 @@ const actions = {
     })
   },
   async logoutUser({ commit }) {
-    await axios.delete("/v1/logout")
+    await axios.delete("../../api/v1/logout")
     commit("setCurrentUser", null)
   },
   async deleteCurrentUser({ commit }) {


### PR DESCRIPTION
## 概要
ブランチ名の修正
ヘッダーとフッターを微調整
ルーティングとドラゴン詳細ページで表記が返されないバグの修正
結果とドラゴンの詳細表示のページで説明文の長さを調整
スマホだとヘッダー下に余白が発生する状態を修正
ユーザーページの改善

## コメント
残すは新ロゴをヘッダーとトップページに調整して実装
過去の診断結果ページもいる