### PR TITLE
changed_saving_process_and_data_of_result

### DIFF
--- a/app/controllers/api/v1/results_controller.rb
+++ b/app/controllers/api/v1/results_controller.rb
@@ -13,12 +13,15 @@ module Api
       end
 
       def create
-        user_id = result_params['user_id']
-        user = client.user(user_id)
-        tweets = client.user_timeline(user, count: 5, exclude_replies: true, include_rts: false)
-        analyzed_result = Result.analyzeResult(user, tweets)
+        target_id = result_params['target_account']
+        target = client.user(target_id)
+        tweets = client.user_timeline(target, count: 5, exclude_replies: true, include_rts: false)
+        user = result_params['user_id']
+        analyzed_result = Result.analyzeResult(target, tweets, user)
         @result = Result.new(analyzed_result)
-        if @result.save!
+        if @result.user_id == 0 then
+          render json: @result
+        elsif @result.save then
           render json: @result, status: :created
         else
           render json: @result, status: :bad_request
@@ -32,7 +35,7 @@ module Api
       end
 
       def result_params
-        params.require(:result).permit(:user_id, :dragon_id, :score, :magnitude, :troversion)
+        params.require(:result).permit(:user_id, :dragon_id, :score, :magnitude, :troversion, :target_account)
       end
 
     end

--- a/app/javascript/pages/top.vue
+++ b/app/javascript/pages/top.vue
@@ -42,7 +42,8 @@ export default {
   data() {
     return {
       targetAccount: "",
-      isLoading: false
+      isLoading: false,
+      user_id: "",
     }
   },
   components: {
@@ -71,10 +72,14 @@ export default {
   },
   methods: {
     async startAnalysis() {
-      const targetId = this.targetAccount
+      const target_account = this.targetAccount
+      const user_id = (this.currentUser !== null) ? this.currentUser.twitter_id : 0
       this.isLoading = true
       try {
-        await this.$store.dispatch('results/fetchResult', targetId)
+        await this.$store.dispatch('results/fetchResult', {
+          target_account: target_account,
+          user_id: user_id
+        })
         await this.$store.dispatch('dragons/fetchDragon', this.results.dragon_id)
         this.isLoading = false
         await this.$router.push('/result')

--- a/app/javascript/store/modules/results.js
+++ b/app/javascript/store/modules/results.js
@@ -18,8 +18,11 @@ const mutations = {
 }
 
 const actions = {
-  async fetchResult ({ commit }, targetId) {
-    await axios.post('/v1/results', { user_id: targetId } )
+  async fetchResult ({ commit }, analyzeData) {
+    await axios.post('/v1/results', {
+      target_account: analyzeData.target_account,
+      user_id: analyzeData.user_id
+    })
       .then(res => {
         commit('setResult', res.data)
       })

--- a/app/javascript/store/modules/users.js
+++ b/app/javascript/store/modules/users.js
@@ -1,7 +1,7 @@
 import axios from '../../plugins/axios.js';
 
 const state = {
-  currentUser: ""
+  currentUser: []
 }
 
 const getters = {

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -1,14 +1,14 @@
 class Result < ApplicationRecord
   belongs_to :user, optional: true
 
-  validates :user_id, presence: true
-  validates :dragon_id, presence: true
-  validates :score, presence: true
-  validates :magnitude, presence: true
-  validates :troversion, presence: true
-  validates :target_account, presence: true
+  # validates :user_id, presence: true
+  # validates :dragon_id, presence: true
+  # validates :score, presence: true
+  # validates :magnitude, presence: true
+  # validates :troversion, presence: true
+  # validates :target_account, presence: true
 
-  def self.analyzeResult(user, tweets)
+  def self.analyzeResult(target, tweets, user)
     require "google/cloud/language"
     client = Google::Cloud::Language.language_service do |config|
       if Rails.env.production?
@@ -27,11 +27,11 @@ class Result < ApplicationRecord
       resultScore.push(sentiment.score)
       resultMagnitude.push(sentiment.magnitude)
     end
-    user_id = user.id
-    target_account = user.name
+    user_id = user
+    target_account = target.name
     score = resultScore.sum(0.0) / resultScore.size
     magnitude = resultMagnitude.sum(0.0) / resultMagnitude.size
-    troversion = Result.analyzeTroversion(user, tweets)
+    troversion = Result.analyzeTroversion(target, tweets)
     dragon_id = Result.whichDragon(score, magnitude, troversion)
 
     {
@@ -44,7 +44,7 @@ class Result < ApplicationRecord
     }
   end
 
-  def self.analyzeTroversion(user, tweets)
+  def self.analyzeTroversion(target, tweets)
     resultFavorites = []
     resultRetweets = []
     tweets.each do |tweet|
@@ -69,8 +69,8 @@ class Result < ApplicationRecord
       userFavorites = 0.2
     end
     # フォロワー数
-    if user.followers_count <= 1000
-      userFollowers = user.followers_count / 1000 * 0.2
+    if target.followers_count <= 1000
+      userFollowers = target.followers_count / 1000 * 0.2
     elsif
       userFollowers = 0.2
     end


### PR DESCRIPTION
## 概要
・何故かuser_idに診断対象のアカウントのidを保存するようにしていたので、
　診断したアカウントのidを保存するように変更。
　診断ロジックの変数もuserからtargetにして、userを診断者アカウントを入れる変数に。
・診断対象のアカウントはtarget_accountに保存するように変更。
・ログイン前だったら診断結果を保存しない、ログイン後だったら診断結果を保存するように条　
　件分岐を追加。

## コメント
今更だけどこの仕様だと過去の診断結果を見た時に自分の診断結果を追いにくくなるか？。
