### PR TITLE
Previous Results and Flash Messages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,11 +48,11 @@ group :development do
   gem 'binding_of_caller'
 end
 
-gem 'active_hash'
 gem 'twitter'
 gem 'google-cloud-language'
 gem 'meta-tags'
 gem 'sorcery'
 gem 'config'
+gem 'active_model_serializers'
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,8 +37,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    active_hash (3.1.0)
-      activesupport (>= 5.0.0)
+    active_model_serializers (0.10.13)
+      actionpack (>= 4.1, < 7.1)
+      activemodel (>= 4.1, < 7.1)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (6.0.4.6)
       activesupport (= 6.0.4.6)
       globalid (>= 0.3.6)
@@ -74,6 +77,8 @@ GEM
     buftok (0.2.0)
     builder (3.2.4)
     byebug (11.1.3)
+    case_transform (0.2)
+      activesupport
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
     config (4.0.0)
@@ -213,6 +218,7 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    jsonapi-renderer (0.2.2)
     jwt (2.3.0)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -404,7 +410,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  active_hash
+  active_model_serializers
   better_errors
   binding_of_caller
   bootsnap (>= 1.4.2)

--- a/app/controllers/api/v1/dragons_controller.rb
+++ b/app/controllers/api/v1/dragons_controller.rb
@@ -8,6 +8,11 @@ module Api
         render json: dragon
       end
 
+      def index
+        dragons = Dragon.all
+        render json: dragons
+      end
+
       private
 
       def set_dragon

--- a/app/controllers/api/v1/dragons_controller.rb
+++ b/app/controllers/api/v1/dragons_controller.rb
@@ -9,8 +9,6 @@ module Api
       end
 
       def index
-        dragons = Dragon.all
-        render json: dragons
       end
 
       private

--- a/app/controllers/api/v1/results_controller.rb
+++ b/app/controllers/api/v1/results_controller.rb
@@ -12,7 +12,7 @@ module Api
       end
 
       def show
-        render json: @result
+        render json: @result, include: [:dragon], status: 200
       end
 
       def create
@@ -34,7 +34,7 @@ module Api
       private
 
       def set_result
-        @result = Result.find(params[:id])
+        @result = Result.find_by(id: params[:id])
       end
 
       def result_params

--- a/app/controllers/api/v1/results_controller.rb
+++ b/app/controllers/api/v1/results_controller.rb
@@ -3,9 +3,12 @@ module Api
     class ResultsController < ApplicationController
       before_action :set_result, only: %i[show]
 
+      def previous_results
+        @results = Result.where(user_id: params[:id]).order(created_at: :desc)
+        render json: @results, include: [:dragon], status: 200
+      end
+
       def index
-        @results = Result.all
-        render json: @results
       end
 
       def show
@@ -31,7 +34,7 @@ module Api
       private
 
       def set_result
-        @result = account.find(params[:id])
+        @result = Result.find(params[:id])
       end
 
       def result_params

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -1,6 +1,9 @@
 <template>
-  <div class='d-flex flex-column min-h-screen bg-cover bg-fixed bg-center pt-32' :style="{ backgroundImage: 'url(' + image_src + ')' }">
+  <div class='d-flex flex-column min-h-screen bg-cover bg-fixed bg-center pt-28' :style="{ backgroundImage: 'url(' + image_src + ')' }">
     <TheHeader class='mb-auto' />
+      <transition>
+        <TheFlash v-if="flash.message" />
+      </transition>
       <router-view />
     <TheFooter class='mt-auto' />
   </div>
@@ -9,18 +12,35 @@
 <script>
 import TheHeader from 'components/TheHeader'
 import TheFooter from 'components/TheFooter'
+import TheFlash from 'components/TheFlash'
+import { mapGetters } from 'vuex'
 
 export default {
   components: {
     TheHeader,
     TheFooter,
+    TheFlash
   },
   methods: {
   },
   computed: {
+    ...mapGetters(
+      'flash',['flash']
+    ),
     image_src() {
       return require("../../public/images/topImage.png")
     }
   }
 }
 </script>
+
+<style scoped>
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.5s;
+}
+.fade-enter,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/app/javascript/components/ResultCard.vue
+++ b/app/javascript/components/ResultCard.vue
@@ -2,13 +2,14 @@
   <div class="w-full mx-auto bg-white shadow-md rounded-md px-6 py-4 my-12">
     <div class="sm:flex justify-left py-4">
       <div class="flex items-center">
-        <!-- <img class="h-20 w-20 rounded-full" :src="dragon_image_src" alt=""> -->
+        <img class="h-24 w-24 rounded-full" :src="'../images/' + result.dragon.image" alt="">
         <div class="ml-4 text-left">
           <h3 class="text-3xl text-gray-800 font-medium">{{ result.target_account }}</h3>
           <h3 class="text-3xl text-gray-800 font-medium">{{ result.dragon.name }}</h3>
-          <h3 class="text-3xl text-gray-600">@{{ result.dragon.explanation }}</h3>
+          <h3 class="text-3xl text-gray-800">{{ result.dragon.explanation }}</h3>
+          <h3 class="text-2xl text-gray-400">診断を行った日-{{ result.created_at }}</h3>
         </div>
-     </div>
+      </div>
     </div>
   </div>
 </template>
@@ -23,6 +24,10 @@ export default {
     }
   },
   props: {
+    result: {
+      type: Array,
+      required: true
+    },
   },
   computed: {
     ...mapGetters(

--- a/app/javascript/components/ResultsCard.vue
+++ b/app/javascript/components/ResultsCard.vue
@@ -2,51 +2,39 @@
   <div class="w-full mx-auto bg-white shadow-md rounded-md px-6 py-4 my-12">
     <div class="sm:flex justify-left py-4">
       <div class="flex items-center">
-        <img class="h-20 w-20 rounded-full" :src="user.image" alt="">
+        <!-- <img class="h-20 w-20 rounded-full" :src="dragon_image_src" alt=""> -->
         <div class="ml-4 text-left">
-          <h3 class="text-3xl text-gray-800 font-medium">{{ user.name }}</h3>
-          <h3 class="text-3xl text-gray-600">@{{ user.screen_name }}</h3>
+          <h3 class="text-3xl text-gray-800 font-medium">{{ result.target_account }}</h3>
+          <h3 class="text-3xl text-gray-800 font-medium">{{ result.dragon.name }}</h3>
+          <h3 class="text-3xl text-gray-600">@{{ result.dragon.explanation }}</h3>
         </div>
      </div>
-    </div>
-    <div class="text-2xl pt-4 border-t-2">次のボタンを押すとTwitterの最新プロフィールに更新されます</div>
-    <div class="flex flex-row justify-center items-center my-4">
-      <button class=" bg-twitterBlue hover:bg-blue-700 text-white text-2xl font-bold py-4 px-4 rounded" @click="updateUserSettings">
-        <i class="ri-restart-line mx-2"></i>ユーザー情報を更新する
-      </button>
-    </div>
-    <div class="flex flex-row justify-center items-center text-2xl pt-4 border-t-2">
-      <input type="checkbox" v-model="checkbox" class="mr-2">退会する場合は全ての情報が削除されます。
-    </div>
-    <div class="my-4">
-      <button class="bg-red-500 hover:bg-red-700 text-white text-2xl font-bold py-4 px-4 rounded" @click="logoutUser" :disabled="!checkbox">退会する</button>
     </div>
   </div>
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
+
 export default {
   name: "ResultsCard",
   data() {
-    return {
-      checkbox: false
+    return{
     }
   },
   props: {
-    user: {
-      type: Object,
-      required: true
-    },
   },
   computed: {
+    ...mapGetters(
+      'results', ['results']
+    ),
+    dragon_image_src() {
+      const result = this.results[0]
+        return require("../../../public/images/"  + result.dragon.image)
+    },
   },
   methods: {
-    updateUserSettings() {
-      this.$emit("update-Settings");
-    },
-    logoutUser() {
-      this.$emit("logout")
-    }
+
   }
 }
 </script>

--- a/app/javascript/components/TheFlash.vue
+++ b/app/javascript/components/TheFlash.vue
@@ -1,0 +1,36 @@
+<template>
+  <div>
+    <div v-if="flash.type == 'info'" class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded fixed top-28 w-full">
+      {{ flash.message }}
+    </div>
+    <div v-if="flash.type == 'alert'" class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded fixed top-28 w-full">
+      {{ flash.message }}
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapGetters } from "vuex"
+
+export default {
+  data() {
+    return {
+      isShow: true
+    }
+  },
+  computed: {
+    ...mapGetters({ flash: "flash/flash" })
+  },
+  mounted() {
+    setTimeout(() => {
+      this.$store.dispatch("flash/fetchFlash",{
+        type: "",
+        message: ""
+      })
+    }, 2000)
+  }
+}
+</script>
+
+<style scoped>
+</style>

--- a/app/javascript/components/TheHeader.vue
+++ b/app/javascript/components/TheHeader.vue
@@ -1,6 +1,6 @@
 <template>
   <header>
-    <nav class='w-full text-gray-500 bg-gray-100 p-2 fixed top-0'>
+    <nav class='w-full text-gray-500 bg-gray-100 py-4 fixed top-0'>
       <div class='px-12 mx-auto items-center'>
         <div class="flex justify-between items-center">
         <router-link to="/" class='flex justify-center items-center'>
@@ -9,7 +9,7 @@
         <div>
           <a
             href='/api/v1/oauth/twitter' v-if="!currentUser"
-            class='p-2 lg:px-4 md:mx-2 text-xl text-gray-500 text-center border border-transparent rounded hover:bg-red-100 hover:text-red-700 transition-colors duration-300'
+            class='px-2 lg:px-4 md:mx-2 text-2xl text-gray-500 text-center border border-transparent rounded hover:bg-red-100 hover:text-red-700 transition-colors duration-300'
           >
             Twitter認証によるユーザー登録
           </a>
@@ -66,13 +66,16 @@ export default {
   },
   methods: {
     async logout() {
-      try {
-        await this.$store.dispatch('users/logoutUser')
-        Cookies.remove('vuex');
-        await this.$router.push('/')
-      } catch (err) {
-        err => console.log(err.response)
-      }
+      await this.$store.dispatch('users/logoutUser')
+      .then(
+        this.$router.push,('/'),
+        this.$store.dispatch('flash/fetchFlash', {
+          type: 'alert',
+          message: 'ログアウトしました。'
+        }))
+      .catch ((err) => {
+        console.log(err.response)
+      })
     },
     closeMenu(){
       this.isOpen = false;

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -13,6 +13,8 @@ import App from '../app.vue'
 import router from '../router/router.js'
 import axios from '../plugins/axios.js'
 import store from '../store/index.js'
+import 'dayjs/locale/ja'
+import dayjs from 'dayjs'
 import '../css/tailwind.css'
 import '../plugins/veevalidate'
 import 'remixicon/fonts/remixicon.css'
@@ -20,6 +22,9 @@ import 'remixicon/fonts/remixicon.css'
 Vue.config.productionTip = false
 Vue.config.devtools = true
 Vue.prototype.$axios = axios
+
+dayjs.locale('ja')
+Vue.prototype.$dayjs = dayjs
 
 document.addEventListener('DOMContentLoaded', () => {
   const app = new Vue({

--- a/app/javascript/pages/Dragon.vue
+++ b/app/javascript/pages/Dragon.vue
@@ -4,21 +4,21 @@
       <div class="col-start-2 col-span-10 mt-20 md:mt-0">
         <div class="text-2xl inline p-2 text-white font-bold border-b-8 border-white md:text-4xl">{{ title }}</div>
       </div>
-      <div class="text-center text-white col-start-2 col-span-10 px-10 pb-10 mx-auto" v-if="dragon.attributes">
+      <div class="text-center text-white col-start-2 col-span-10 px-10 pb-10 mx-auto" v-if="dragon">
         <div class="text-6xl font-bold">
-          <h3>{{ dragon.attributes.name }}</h3>
+          <h3>{{ dragon.name }}</h3>
         </div>
         <div class="m-auto">
           <img :src="dragon_image_src">
         </div>
         <div class="p-4 m-4 border-4 border-white rounded-md font-bold mx-4">
           <div class="text-3xl inline font-bold border-b-2 border-white">性格</div>
-          <div class="text-3xl m-4">{{ dragon.attributes.explanation }}</div>
-          <div class="text-2xl m-4 text-left">{{ dragon.attributes.personality }}</div>
+          <div class="text-3xl m-4">{{ dragon.explanation }}</div>
+          <div class="text-2xl m-4 text-left">{{ dragon.personality }}</div>
         </div>
         <div class="p-4 m-4 border-4 border-white rounded-md font-bold mx-4">
           <div class="text-3xl inline font-bold border-b-2 border-white">アドバイス</div>
-          <div class="text-2xl m-4 text-left">{{ dragon.attributes.advice }}</div>
+          <div class="text-2xl m-4 text-left">{{ dragon.advice }}</div>
         </div>
       </div>
     </div>
@@ -45,7 +45,7 @@ export default {
       'dragons', ['dragons']
     ),
     dragon_image_src() {
-        return require("../../../public/images/" + this.dragon.attributes.image)
+        return require("../../../public/images/" + this.dragon.image)
     },
     currentPath() {
       return this.$route.path

--- a/app/javascript/pages/PreviousResults.vue
+++ b/app/javascript/pages/PreviousResults.vue
@@ -5,15 +5,16 @@
         <div class="text-3xl inline p-2 text-white font-bold border-b-8 border-white md:text-4xl">{{ title }}</div>
       </div>
       <div class="items-center col-start-2 col-span-10">
-        <!-- <ResultsCard v-for="result in results" v-bind:key="result.id" /> -->
+        <!-- <ResultCard v-for="result in results" v-bind:key="result.id" :result="results"></ResultCard> -->
         <div v-for="result in results" v-bind:key="result.id" class="w-full mx-auto bg-white shadow-md rounded-md px-6 py-4 my-12">
           <div class="sm:flex justify-left py-4">
             <div class="flex items-center">
-              <img class="h-20 w-20 rounded-full" :src="'../images/'  + result.dragon.image" alt="">
+              <img class="h-24 w-24 rounded-full" :src="'../images/'  + result.dragon.image" alt="">
               <div class="ml-4 text-left">
                 <h3 class="text-3xl text-gray-800 font-medium">{{ result.target_account }}</h3>
                 <h3 class="text-3xl text-gray-800 font-medium">{{ result.dragon.name }}</h3>
-                <h3 class="text-3xl text-gray-600">{{ result.dragon.explanation }}</h3>
+                <h3 class="text-3xl text-gray-800">{{ result.dragon.explanation }}</h3>
+                <h3 class="text-2xl text-gray-400">診断を行った日-{{ format(result.created_at) }}</h3>
               </div>
             </div>
           </div>
@@ -26,25 +27,27 @@
 <script>
 import axios from 'axios';
 import { mapGetters } from 'vuex'
-// import ResultsCard from '../components/ResultsCard';
+import dayjs from 'dayjs';
+// import ResultCard from '../components/ResultCard';
 
 export default {
   name: "PreviousResults",
   components: {
-    // ResultsCard,
+    // ResultCard,
   },
   data() {
     return {
       title: "過去の診断結果",
+      results: {}
     };
   },
   computed: {
     ...mapGetters(
       'users', ['currentUser']
     ),
-    ...mapGetters(
-      'results', ['results']
-    ),
+    // ...mapGetters(
+    //   'results', ['results']
+    // ),
     dragon_image_src() {
       const result = this.results[0]
         return require("../../../public/images/"  + result.dragon.image)
@@ -58,8 +61,12 @@ export default {
       await axios.get(`/api/v1/results/${this.currentUser.twitter_id}/previous_results`)
       .then(res => {
         this.results = res.data
-        this.$store.commit('results/setResult', res.data)
+        // this.$store.commit('results/setResult', res.data)
       })
+    },
+    format(date) {
+      let created_at = dayjs(date).format('YYYY-MM-DD');
+      return created_at;
     },
   }
 }

--- a/app/javascript/pages/PreviousResults.vue
+++ b/app/javascript/pages/PreviousResults.vue
@@ -5,7 +5,19 @@
         <div class="text-3xl inline p-2 text-white font-bold border-b-8 border-white md:text-4xl">{{ title }}</div>
       </div>
       <div class="items-center col-start-2 col-span-10">
-        <ResultsCard :user="currentUser" @update-Settings="updateUserSettings" @logout="deleteUser" />
+        <!-- <ResultsCard v-for="result in results" v-bind:key="result.id" /> -->
+        <div v-for="result in results" v-bind:key="result.id" class="w-full mx-auto bg-white shadow-md rounded-md px-6 py-4 my-12">
+          <div class="sm:flex justify-left py-4">
+            <div class="flex items-center">
+              <img class="h-20 w-20 rounded-full" :src="'../images/'  + result.dragon.image" alt="">
+              <div class="ml-4 text-left">
+                <h3 class="text-3xl text-gray-800 font-medium">{{ result.target_account }}</h3>
+                <h3 class="text-3xl text-gray-800 font-medium">{{ result.dragon.name }}</h3>
+                <h3 class="text-3xl text-gray-600">{{ result.dragon.explanation }}</h3>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -14,57 +26,40 @@
 <script>
 import axios from 'axios';
 import { mapGetters } from 'vuex'
-import ResultsCard from '../components/ResultsCard';
+// import ResultsCard from '../components/ResultsCard';
 
 export default {
   name: "PreviousResults",
   components: {
-    ResultsCard,
+    // ResultsCard,
   },
   data() {
     return {
       title: "過去の診断結果",
-      results: {},
     };
   },
   computed: {
     ...mapGetters(
-      'results', ['setResult']
-    ),
-    ...mapGetters(
       'users', ['currentUser']
     ),
-    currentPath() {
-      return this.$route.path
+    ...mapGetters(
+      'results', ['results']
+    ),
+    dragon_image_src() {
+      const result = this.results[0]
+        return require("../../../public/images/"  + result.dragon.image)
     },
-  },
-  watch: {
-    currentPath: function() {
-      this.fetchResults()
-    }
   },
   mounted() {
     this.fetchResults()
   },
   methods: {
     async fetchResults() {
-     const res = await axios.get(`/api/v1/results/${this.$route.params.twitter_id}`)
-     this.user = res.data
-    },
-    async updateUserSettings() {
-      await axios.patch("/api/v1/user_settings")
+      await axios.get(`/api/v1/results/${this.currentUser.twitter_id}/previous_results`)
       .then(res => {
-        this.$store.commit("users/setCurrentUser", res.data)
+        this.results = res.data
+        this.$store.commit('results/setResult', res.data)
       })
-    },
-   async deleteUser() {
-      try {
-        await axios.delete("/api/v1/user_settings")
-        await this.$router.push('/')
-      } catch(err){
-        this.$store.commit("users/setCurrentUser", null)
-        err => console.log(err.response)
-      }
     },
   }
 }

--- a/app/javascript/pages/PreviousResults.vue
+++ b/app/javascript/pages/PreviousResults.vue
@@ -7,17 +7,19 @@
       <div class="items-center col-start-2 col-span-10">
         <!-- <ResultCard v-for="result in results" v-bind:key="result.id" :result="results"></ResultCard> -->
         <div v-for="result in results" v-bind:key="result.id" class="w-full mx-auto bg-white shadow-md rounded-md px-6 py-4 my-12">
-          <div class="sm:flex justify-left py-4">
-            <div class="flex items-center">
-              <img class="h-24 w-24 rounded-full" :src="'../images/'  + result.dragon.image" alt="">
-              <div class="ml-4 text-left">
-                <h3 class="text-3xl text-gray-800 font-medium">{{ result.target_account }}</h3>
-                <h3 class="text-3xl text-gray-800 font-medium">{{ result.dragon.name }}</h3>
-                <h3 class="text-3xl text-gray-800">{{ result.dragon.explanation }}</h3>
-                <h3 class="text-2xl text-gray-400">診断を行った日-{{ format(result.created_at) }}</h3>
+          <router-link :to="`/previous/${result.id}`">
+            <div class="sm:flex justify-left py-4">
+              <div class="flex items-center">
+                <img class="h-24 w-24" :src="'../images/'  + result.dragon.image" alt="">
+                <div class="ml-4 text-left">
+                  <h3 class="text-3xl text-gray-800 font-medium">{{ result.target_account }}</h3>
+                  <h3 class="text-3xl text-gray-800 font-medium">{{ result.dragon.name }}</h3>
+                  <h3 class="text-3xl text-gray-800">{{ result.dragon.explanation }}</h3>
+                  <h3 class="text-2xl text-gray-400">診断を行った日-{{ format(result.created_at) }}</h3>
+                </div>
               </div>
             </div>
-          </div>
+          </router-link>
         </div>
       </div>
     </div>

--- a/app/javascript/pages/PreviousShow.vue
+++ b/app/javascript/pages/PreviousShow.vue
@@ -1,0 +1,70 @@
+<template>
+  <div class="text-center">
+    <div class="grid grid-cols-12 gap-10 md:pt-20">
+      <div class="col-start-2 col-span-10 mt-20 md:mt-0">
+        <div class="text-2xl inline p-2 text-white font-bold border-b-8 border-white md:text-4xl">{{ result.target_account }}さんの心に潜むドラゴンは…</div>
+      </div>
+      <div class="text-center text-white col-start-2 col-span-10 px-10 pb-10 mx-auto" v-if="result">
+        <div class="text-6xl font-bold">
+          <h3>{{ result.dragon.name }}</h3>
+        </div>
+        <div class="m-auto">
+          <img :src="'../images/'  + result.dragon.image">
+        </div>
+        <div class="p-4 m-4 border-4 border-white rounded-md font-bold mx-4">
+          <div class="text-3xl inline font-bold border-b-2 border-white">性格</div>
+          <div class="text-3xl m-4">{{ result.dragon.explanation }}</div>
+          <div class="text-2xl m-4 text-left">{{ result.dragon.personality }}</div>
+        </div>
+        <div class="p-4 m-4 border-4 border-white rounded-md font-bold mx-4">
+          <div class="text-3xl inline font-bold border-b-2 border-white">アドバイス</div>
+          <div class="text-2xl m-4 text-left">{{ result.dragon.advice }}</div>
+        </div>
+      </div>
+    </div>
+    <div class="text-center px-4 pb-12">
+      <router-link to="/previous">
+        <button class=" bg-red-500 hover:bg-red-700 font-bold py-4 px-8 text-2xl text-white rounded w-52 items-center">戻る</button>
+      </router-link>
+    </div>
+  </div>
+</template>
+
+<script>
+import axios from 'axios';
+
+export default {
+  name: "PreviousShow",
+  data() {
+    return {
+      result : {},
+    };
+  },
+  computed: {
+    dragon_image_src() {
+        return require("../../../public/images/" + this.result.dragon.image)
+    },
+    currentPath() {
+      return this.$route.path
+    },
+  },
+  watch: {
+    currentPath: function() {
+      this.fetchResult()
+    }
+  },
+  mounted() {
+    this.fetchResult()
+  },
+  methods: {
+    async fetchResult() {
+      const res = await axios.get(`/api/v1/results/${this.$route.params.id}`)
+      this.result = res.data
+      console.log(this.result.dragon)
+    }
+  }
+}
+</script>
+
+<style scoped>
+</style>

--- a/app/javascript/pages/User.vue
+++ b/app/javascript/pages/User.vue
@@ -52,16 +52,24 @@ export default {
       await axios.patch("/api/v1/user_settings")
       .then(res => {
         this.$store.commit("users/setCurrentUser", res.data)
+        this.$store.dispatch('flash/fetchFlash', {
+          type: 'info',
+          message: 'ユーザー情報を更新しました。'
+        })
       })
     },
    async deleteUser() {
-      try {
-        await axios.delete("/api/v1/user_settings")
-        await this.$router.push('/')
-      } catch(err){
-        this.$store.commit("users/setCurrentUser", null)
-        err => console.log(err.response)
-      }
+      await axios.delete("/api/v1/user_settings")
+      .then(
+        this.$router.push('/'),
+        this.$store.commit("users/setCurrentUser", null),
+        this.$store.dispatch('flash/fetchFlash', {
+          type: 'alert',
+          message: '退会しました。'
+      }))
+      .catch((err) => {
+        console.log(err.response)
+      })
     },
   }
 }

--- a/app/javascript/pages/result.vue
+++ b/app/javascript/pages/result.vue
@@ -4,21 +4,21 @@
       <div class="col-start-2 col-span-10 mt-20 md:mt-0">
         <div class="text-2xl inline p-2 text-white font-bold border-b-8 border-white md:text-4xl">{{ results.target_account }}さんの心のドラゴンは…</div>
       </div>
-      <div class="text-center text-white col-start-2 col-span-10 px-10 pb-10 mx-auto" v-if="dragons.attributes">
+      <div class="text-center text-white col-start-2 col-span-10 px-10 pb-10 mx-auto" v-if="dragons">
         <div class="text-6xl font-bold">
-          <h3>{{ dragons.attributes.name }}</h3>
+          <h3>{{ dragons.name }}</h3>
         </div>
         <div class="m-auto">
           <img :src="dragon_image_src">
         </div>
         <div class="p-4 m-4 border-4 border-white rounded-md font-bold mx-4">
           <div class="text-3xl inline font-bold border-b-2 border-white">性格</div>
-          <div class="text-3xl m-4">{{ dragons.attributes.explanation }}</div>
-          <div class="text-2xl m-4 text-left">{{ dragons.attributes.personality }}</div>
+          <div class="text-3xl m-4">{{ dragons.explanation }}</div>
+          <div class="text-2xl m-4 text-left">{{ dragons.personality }}</div>
         </div>
         <div class="p-4 m-4 border-4 border-white rounded-md font-bold mx-4">
           <div class="text-3xl inline font-bold border-b-2 border-white">アドバイス</div>
-          <div class="text-2xl m-4 text-left">{{ dragons.attributes.advice }}</div>
+          <div class="text-2xl m-4 text-left">{{ dragons.advice }}</div>
         </div>
       </div>
     </div>
@@ -45,8 +45,8 @@ export default {
   },
   methods: {
     twitterShare(){
-      const url = `https://www.dragon-twitter-analysis.com/dragons/${this.dragons.attributes.id}`
-      window.open(`https://twitter.com/share?text=${this.results.target_account}さんの心の中のドラゴンは${this.dragons.attributes.name}でした！%0a%23ドラッター%20%23Dratter%0a&url=${url}`, '_blank')
+      const url = `https://www.dragon-twitter-analysis.com/dragons/${this.dragons.id}`
+      window.open(`https://twitter.com/share?text=${this.results.target_account}さんの心の中のドラゴンは${this.dragons.name}でした！%0a%23ドラッター%20%23Dratter%0a&url=${url}`, '_blank')
     }
   },
   computed: {
@@ -57,7 +57,7 @@ export default {
       'results', ['results']
     ),
     dragon_image_src() {
-        return require("../../../public/images/" + this.dragons.attributes.image)
+        return require("../../../public/images/" + this.dragons.image)
     },
   },
 }

--- a/app/javascript/pages/top.vue
+++ b/app/javascript/pages/top.vue
@@ -9,7 +9,7 @@
           <div class="justify-center pb-16">
             <ValidationProvider v-slot="{ errors }" rules="required">
               <input type="text" v-model="targetAccount" class=" h-20 bg-gray-100 text-4xl p-2 rounded-lg border-4 border-indigo-500 shadow-md focus:outline-none focus:border-indigo-600 w-full" placeholder="idを入力">
-              <span class="block text-white">{{ errors[0] }}</span>
+              <span class="block text-2xl text-white">{{ errors[0] }}</span>
             </ValidationProvider>
           </div>
         <div class="my-32 justify-center">

--- a/app/javascript/router/router.js
+++ b/app/javascript/router/router.js
@@ -10,6 +10,7 @@ import Result from '../pages/Result.vue';
 import Dragon from '../pages/Dragon.vue';
 import User from '../pages/User.vue';
 import PreviousResults from '../pages/PreviousResults.vue';
+import PreviousShow from '../pages/PreviousShow.vue';
 import NotFound from '../pages/shared/NotFound.vue';
 
 Vue.use(Router)
@@ -56,6 +57,11 @@ const router = new Router({
       path: "/previous",
       component: PreviousResults,
       name: "PreviousResults",
+    },
+    {
+      path: "/previous/:id",
+      component: PreviousShow,
+      name: "PreviousShow",
     },
     {
       name: "NotFound",

--- a/app/javascript/store/index.js
+++ b/app/javascript/store/index.js
@@ -6,6 +6,7 @@ import Cookies from 'js-cookie';
 import results from './modules/results'
 import dragons from './modules/dragons'
 import users from './modules/users'
+import flash from './modules/flash'
 
 Vue.use(Vuex)
 
@@ -13,7 +14,8 @@ export default new Vuex.Store({
   modules: {
     results,
     dragons,
-    users
+    users,
+    flash
   },
   plugins: [
     createPersistedState({

--- a/app/javascript/store/modules/flash.js
+++ b/app/javascript/store/modules/flash.js
@@ -1,0 +1,32 @@
+const state = {
+  flash: {
+    type: "",
+    message: ""
+  }
+}
+
+const getters = {
+  flash: state => state.flash,
+  message: state => state.flash.message
+}
+
+const mutations = {
+  setFlash: (state, { type, message }) => {
+    state.flash.type = type
+    state.flash.message = message
+  }
+}
+
+const actions = {
+  fetchFlash ({ commit }, { type, message }) {
+    commit("setFlash", { type, message })
+  }
+}
+
+export default {
+  namespaced: true,
+  state,
+  getters,
+  mutations,
+  actions
+}

--- a/app/javascript/store/modules/results.js
+++ b/app/javascript/store/modules/results.js
@@ -2,18 +2,15 @@ import axios from '../../plugins/axios.js';
 
 const state = {
   results: [],
-  dragon_id: 0
 }
 
 const getters = {
   results: state => state.results,
-  dragon_id: state => state.dragon_id
 }
 
 const mutations = {
   setResult: (state, results) => {
     state.results = results
-    state.dragon_id = results.dragon_id
   },
 }
 

--- a/app/models/dragon.rb
+++ b/app/models/dragon.rb
@@ -1,45 +1,10 @@
-class Dragon < ActiveHash::Base
-  self.data = [
-    { id: 1, name: 'レッドドラゴン', image: 'redDragon.png', explanation: '炎のように熱く燃えるヤツ',
-    personality:
-    'このドラゴンが心の中に住んでるあなたは、正に心が燃えている真っ最中。
-     何事にも精力的に取り組めており、周囲への影響力も大きいあなたは辺りを照らす炎のよう。
-     ', advice: 'Twitterの使い方は順調な様子。熱くなりすぎて入れ込みすぎないように注意！' },
-    { id: 2, name: 'イエロードラゴン', image: 'yellowDragon.png', explanation: 'おしゃれで見栄っ張りな王様',
-    personality:
-    'このドラゴンが心の中に住んでるあなたは、誰かに自分を認めてほしい気持ちが強いかも。
-    色々とおしゃれして見た目を良くしようとしているけど、あまり結果には結びついてはいない様子。
-    ', advice: 'ツイートの内容には力が入っている様子。行動力は低めなので、認められたければもう少し積極的になった方がいいかも。' },
-    { id: 3, name: 'グリーンドラゴン', image: 'greenDragon.png', explanation: '悠然とした長老',
-    personality:
-    'このドラゴンが心の中に住んでるあなたは、メンタルが安定している様子。
-    どっしりと構えて頼れる様はまるで神様。
-    ', advice: 'ポジティブ且つアクティブな一方で、感情は安定しているようです。可能であればこの状態を維持できると良い感じ。' },
-    { id: 4, name: 'ホワイトドラゴン', image: 'whiteDragon.png', explanation: '凍てつくほどクール',
-    personality:
-    'このドラゴンが心の中に住んでるあなたは、淡々と事を進める職人気質。
-    その冷静さは絶対零度が如く。
-    ', advice: 'ツイート内容は前向きだけど、感情の起伏は小さい模様。Twitter利用には消極的なようなので、もう少しアクティブな方が得られるものがあるかも。' },
-    { id: 5, name: 'グレードラゴン', image: 'grayDragon.png', explanation: '毒々しさMAX' ,
-    personality:
-    'このドラゴンが心の中に住んでるあなたは、ネガティブな感情を周囲に出し過ぎな傾向。
-    周りを腐食させる毒のせいで他のドラゴンや人が離れていってしまうかも',
-    advice:
-    'ネガティブ度が強い感情的なツイートを多くしがちな様子。一旦Twitterの使い方を見直して見るのが吉。' },
-    { id: 6, name: 'ブルードラゴン', image: 'blueDragon.png', explanation: '怒らすと怖い海の主',
-    personality:
-    'このドラゴンが心の中に住んでるあなたは、言葉の内に強い感情を秘めている様子。
-    海のように一見穏やかに見えても、内には凶暴な感情が見え隠れしている。
-    ', advice: 'ツイート頻度は高くないけど、言いたいことが溜まっているかも。Twitter以外の場所で本音を解消できると良し。' },
-    { id: 7, name: 'パープルドラゴン', image: 'purpleDragon.png', explanation: 'ダウナーな構ってちゃん',
-    personality:
-    'このドラゴンが心のなかに住んでいるあなたは、他のドラゴンや人が恋しい様子。
-    普段は大人しいのに周囲にちょっかいを出す姿は猫っぽい。
-    ', advice: 'Twitterの使用頻度が高い他、病みツイートをしてしまう傾向あり。場合によってはTwitter離れして気持ちを落ち着けよう。' },
-    { id: 8, name: 'ブラックドラゴン', image: 'blackDragon.png', explanation: '病みがちな闇の竜',
-    personality:
-    'このドラゴンが心のなかに住んでいるあなたは、ちょっとお疲れ気味な模様。
-    あまりに闇が濃くなると自分の尻尾を噛んでしまうかも。
-    ', advice: '病みツイートをする傾向にあるけど、Twitterの使用頻度も高くない様子。辛い時は無理にTwitterじゃなくても現実の頼れる人に相談していいかも。' }
-  ]
+class Dragon < ApplicationRecord
+  has_many :results
+
+  validates :name, presence: true
+  validates :image, presence: true
+  validates :explanation, presence: true
+  validates :personality, presence: true
+  validates :advice, presence: true
+
 end

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -1,12 +1,13 @@
 class Result < ApplicationRecord
   belongs_to :user, optional: true
+  belongs_to :dragon
 
-  # validates :user_id, presence: true
-  # validates :dragon_id, presence: true
-  # validates :score, presence: true
-  # validates :magnitude, presence: true
-  # validates :troversion, presence: true
-  # validates :target_account, presence: true
+  validates :user_id, presence: true
+  validates :dragon_id, presence: true
+  validates :score, presence: true
+  validates :magnitude, presence: true
+  validates :troversion, presence: true
+  validates :target_account, presence: true
 
   def self.analyzeResult(target, tweets, user)
     require "google/cloud/language"

--- a/app/serializers/dragon_serializer.rb
+++ b/app/serializers/dragon_serializer.rb
@@ -1,0 +1,5 @@
+class DragonSerializer < ActiveModel::Serializer
+  attributes :id, :name, :image, :explanation, :personality, :advice
+
+  has_many :results
+end

--- a/app/serializers/result_serializer.rb
+++ b/app/serializers/result_serializer.rb
@@ -1,0 +1,5 @@
+class ResultSerializer < ActiveModel::Serializer
+  attributes :id, :dragon_id, :user_id, :target_account, :score, :magnitude, :troversion, :created_at
+
+  belongs_to :dragon
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,8 +8,12 @@ Rails.application.routes.draw do
       get 'oauth/:provider', to: 'oauths#oauth', as: :auth_at_provider
       delete 'logout', to: 'user_sessions#destroy'
       resources :accounts, only: %i[index create show]
-      resources :results, only: %i[index create show]
-      resources :dragons, only: %i[show]
+      resources :results, only: %i[index create show] do
+        member do
+          get 'previous_results'
+        end
+      end
+      resources :dragons, only: %i[show index]
       resources :users, only: %i[index edit update show destroy] do
         collection do
           get 'me'

--- a/db/migrate/20220610031443_create_dragons.rb
+++ b/db/migrate/20220610031443_create_dragons.rb
@@ -1,0 +1,13 @@
+class CreateDragons < ActiveRecord::Migration[6.0]
+  def change
+    create_table :dragons do |t|
+      t.string :name, null: false
+      t.string :image, null: false
+      t.string :explanation, null: false
+      t.string :personality, null: false
+      t.string :advice, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_03_104316) do
+ActiveRecord::Schema.define(version: 2022_06_10_031443) do
 
   create_table "authentications", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -19,6 +19,16 @@ ActiveRecord::Schema.define(version: 2022_06_03_104316) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid"
+  end
+
+  create_table "dragons", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "image", null: false
+    t.string "explanation", null: false
+    t.string "personality", null: false
+    t.string "advice", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "results", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "acorn": "^8.7.0",
     "autoprefixer": "9.8.6",
     "axios": "^0.21.1",
+    "dayjs": "^1.11.3",
     "js-cookie": "^3.0.1",
     "node-sass": "^7.0.1",
     "postcss": "^8.3.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2684,6 +2684,11 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+dayjs@^1.11.3:
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.3.tgz#4754eb694a624057b9ad2224b67b15d552589258"
+  integrity sha512-xxwlswWOlGhzgQ4TKzASQkUhqERI3egRNqgV4ScR8wlANA/A9tZ7miXa44vTTKEq5l7vWoL5G57bG3zA+Kow0A==
+
 de-indent@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"


### PR DESCRIPTION
## 概要
・ドラゴンのデータをActiveHashからMysqlに登録。
・gem active_model_serialzerを導入。
　過去の診断結果をDBから引っ張ってくる時、ドラゴンのデータを配列に追加するように変更。
・過去の診断結果を一覧で表示するページを作成。
・dayjsを導入。過去の結果一覧で診断日時を表示。
・一部のアクションを行った際にフラッシュメッセージを表示するように変更。

## コメント
・細かい修正は本リリース後に修正していくことにする。
